### PR TITLE
add ollama access

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1.1.0": {}
+		"ghcr.io/devcontainers/features/github-cli:1.1.0": {},
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
 	},
 	"forwardPorts": [3000, 9323],
 	"portsAttributes": {
@@ -17,7 +19,18 @@
 		"9323": {
 			"label": "playwright inspector"
 		}
-	}
+	},
+
+
+	"remoteEnv": {
+		"ANTHROPIC_AUTH_TOKEN":"ollama",
+		//"ANTHROPIC_BASE_URL":"http://$WINDOWS_HOST:11434", //set .env for initializeCommand
+		"ANTHROPIC_MODEL":"gpt-oss"
+	},
+
+
+	"initializeCommand": "ip route | grep default | awk '{print \"ANTHROPIC_BASE_URL=http://\" $3 \":11434\"}' | head -1 > ${localWorkspaceFolder}/.devcontainer/.env",
+	"runArgs": [ "--env-file", "${localWorkspaceFolder}/.devcontainer/.env"]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 build
 coverage
 
+.devcontainer/.env
+
+
 .claude/*local.json
 
 playwright-report/*


### PR DESCRIPTION
devcontainer内からollamaのclaudeモードへアクセスできるように設定を追加。

参考：
https://zenn.dev/onozaty/articles/devcontainer-host-access?locale=en#2-4.-%E2%9C%85-use-the-default-gateway-address-on-the-wsl2-side

- WSL2側のネットワーク設定をミラーモードからNATに変更する。
- WINDOWS_HOSTのIPをinitializeCommandで取得して.envへ設定する。
- 上記の設定を使って環境変数を読み込む

