### PR TITLE
fix devcontainer and claude.md

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,19 +30,10 @@
 
 
 	"initializeCommand": "ip route | grep default | awk '{print \"ANTHROPIC_BASE_URL=http://\" $3 \":11434\"}' | head -1 > ${localWorkspaceFolder}/.devcontainer/.env",
-	"runArgs": [ "--env-file", "${localWorkspaceFolder}/.devcontainer/.env"]
+	"runArgs": [ "--env-file", "${localWorkspaceFolder}/.devcontainer/.env"],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-	// Use 'postStartCommand' to run commands after the container starts.
-
-	
-	// Configure tool-specific properties.
-	
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"mounts": [
+		"source=${localEnv:HOME}/.claude/skills,target=/home/node/.claude/skills,type=bind,readonly"
+	],
+	"remoteUser": "node"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   5. ローカルテスト・lint                                                                                     
   npm test                                                                                                    
   npm run lint                                                                                                
-    - すべてパスすることを確認。失敗した場合はステップ 2 に戻り、修正して再コミット。                         
+    - すべてパスすることを確認。失敗した場合はステップ 2 に戻り、修正して再コミット。   
+  5. TODO.mdの更新
+    - 実施したタスクについて実施済みとしてチェックしてコミットする。                      
   6. リモートへプッシュ                                                                                       
   git push -u origin feature/〈説明〉                                                                         
     - -u で追跡設定を行い、以降は git push だけで更新可能。                                                   


### PR DESCRIPTION
claudecodeで開発skill以外のskillとして wsl側の.claude/skillsからmountして使用できるように修正。

CLAUDE.mdでTODO.mdの更新する手順が漏れていたので追加。