### PR TITLE
add postCreateCommand for create and permittion change on claude/sess…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,8 @@
 
 	"initializeCommand": "ip route | grep default | awk '{print \"ANTHROPIC_BASE_URL=http://\" $3 \":11434\"}' | head -1 > ${localWorkspaceFolder}/.devcontainer/.env",
 	"runArgs": [ "--env-file", "${localWorkspaceFolder}/.devcontainer/.env"],
+ 	"postCreateCommand": "./.devcontainer/postCreateCommand.sh",
+
 
 	"mounts": [
 		"source=${localEnv:HOME}/.claude/skills,target=/home/node/.claude/skills,type=bind,readonly"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,1 @@
+sudo mkdir -p /home/node/.claude/session-env && sudo chown node /home/node/.claude/session-env


### PR DESCRIPTION
claude code が作業する際に、~/.claude/session-env にディレクトリを作成してから作業するようだが、
~/.claudeのオーナーがrootになっていて、 session-envディレクトリが作成できない問題が起きていた。

session-envディレクトリをnodeオーナーとして作成するようにスクリプトを追加しておく。