### PR TITLE
remove event on push feature/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feature/**']
+    branches: [master, develop]
   pull_request:
     branches: [master, develop]
 


### PR DESCRIPTION
ciでfeatureのpushとmasterへのPRで2重起動しているのがもったいないのでfeatureブランチのpushでCIは稼働させないよう対応。