### PR TITLE
fix image path

### DIFF
--- a/src/components/AnswerResultsView.tsx
+++ b/src/components/AnswerResultsView.tsx
@@ -68,7 +68,7 @@ export default function AnswerResultsView({ results }: AnswerResultsViewProps) {
     >
       <div>しゅうりょうー</div>
       <div>{(totalLapTime / 1000).toFixed(3)}秒でできたよ。</div>
-      <img src={`/img/grade${grade}.png`} alt="grade" />
+      <img src={`./img/grade${grade}.png`} alt="grade" />
       <table className="answer-results-view">
         <thead>
           <tr>


### PR DESCRIPTION
github pages にデプロイした際のbase urlが `<img src={` ....` と変数化されていることで効いていないようなので、相対パスに変更しておく。

TODO:base urlを取得するよい方法があればそちらに別途変更する。
